### PR TITLE
rainbow: Gpio15 is now Gpio4

### DIFF
--- a/src/boards/esp.h
+++ b/src/boards/esp.h
@@ -15,8 +15,8 @@ public:
 	virtual uint8 tx() = 0;
 
 	// General purpose I/O pins
-	virtual void setGpio15(bool v) = 0;
-	virtual bool getGpio15() = 0;
+	virtual void setGpio4(bool v) = 0;
+	virtual bool getGpio4() = 0;
 };
 
 #endif

--- a/src/boards/nesnet.cpp
+++ b/src/boards/nesnet.cpp
@@ -59,7 +59,7 @@ static DECLFR(NESNETReadFlags) {
 
 static void NESNETMapIrq(int32) {
 	if (irq_enable) {
-		if (esp->getGpio15()) {
+		if (esp->getGpio4()) {
 			X6502_IRQBegin(FCEU_IQEXT);
 		} else {
 			X6502_IRQEnd(FCEU_IQEXT);

--- a/src/boards/nesnet_esp.h
+++ b/src/boards/nesnet_esp.h
@@ -19,8 +19,8 @@ public:
 	void rx(uint8 v) override;
 	uint8 tx() override;
 
-	void setGpio15(bool /*v*/) override {}
-	bool getGpio15() override { return false; }
+	void setGpio4(bool /*v*/) override {}
+	bool getGpio4() override { return false; }
 
 private:
 	void cmdHandlerVariable();

--- a/src/boards/rainbow.cpp
+++ b/src/boards/rainbow.cpp
@@ -128,7 +128,7 @@ static bool esp_enable = true;
 static bool irq_enable = true;
 
 static DECLFR(RainbowEspReadFlags) {
-	uint8 esp_rts_flag = esp->getGpio15() ? 0x80 : 0x00;
+	uint8 esp_rts_flag = esp->getGpio4() ? 0x80 : 0x00;
 	uint8 esp_enable_flag = esp_enable ? 0x01 : 0x00;
 	uint8 irq_enable_flag = irq_enable ? 0x40 : 0x00;
 	UDBG("RAINBOW read flags %04x => %02x\n", A, esp_rts_flag | esp_enable_flag | irq_enable_flag);
@@ -138,7 +138,7 @@ static DECLFR(RainbowEspReadFlags) {
 static void RainbowEspMapIrq(int32) {
 	if (irq_enable)
 	{
-		if (esp->getGpio15())
+		if (esp->getGpio4())
 		{
 			X6502_IRQBegin(FCEU_IQEXT);
 		}
@@ -296,7 +296,7 @@ static DECLFR(RainbowRead) {
 		return esp->tx();
 	case 0x5001:
 	{
-		uint8 esp_rts_flag = esp->getGpio15() ? 0x80 : 0x00;
+		uint8 esp_rts_flag = esp->getGpio4() ? 0x80 : 0x00;
 		uint8 esp_enable_flag = esp_enable ? 0x01 : 0x00;
 		uint8 irq_enable_flag = irq_enable ? 0x40 : 0x00;
 		return esp_rts_flag | esp_enable_flag | irq_enable_flag;

--- a/src/boards/rainbow512.cpp
+++ b/src/boards/rainbow512.cpp
@@ -78,7 +78,7 @@ static DECLFW(RAINBOW512WriteFlags) {
 }
 
 static DECLFR(RAINBOW512ReadFlags) {
-	uint8 esp_rts_flag = esp->getGpio15() ? 0x80 : 0x00;
+	uint8 esp_rts_flag = esp->getGpio4() ? 0x80 : 0x00;
 	uint8 esp_enable_flag = esp_enable ? 0x01 : 0x00;
 	uint8 irq_enable_flag = irq_enable ? 0x40 : 0x00;
 	UDBG("RAINBOW read flags %04x => %02x\n", A, esp_rts_flag | esp_enable_flag | irq_enable_flag);
@@ -87,7 +87,7 @@ static DECLFR(RAINBOW512ReadFlags) {
 
 static void RAINBOW512MapIrq(int32) {
 	if (irq_enable) {
-		if (esp->getGpio15()) {
+		if (esp->getGpio4()) {
 			X6502_IRQBegin(FCEU_IQEXT);
 		} else {
 			X6502_IRQEnd(FCEU_IQEXT);

--- a/src/boards/rainbow_esp.cpp
+++ b/src/boards/rainbow_esp.cpp
@@ -179,10 +179,10 @@ uint8 BrokeStudioFirmware::tx() {
 	return last_byte_read;
 }
 
-void BrokeStudioFirmware::setGpio15(bool /*v*/) {
+void BrokeStudioFirmware::setGpio4(bool /*v*/) {
 }
 
-bool BrokeStudioFirmware::getGpio15() {
+bool BrokeStudioFirmware::getGpio4() {
 	this->receiveDataFromServer();
 	this->receivePingResult();
 	return !(this->tx_buffer.empty() && this->tx_messages.empty());

--- a/src/boards/rainbow_esp.h
+++ b/src/boards/rainbow_esp.h
@@ -28,8 +28,8 @@ public:
 	void rx(uint8 v) override;
 	uint8 tx() override;
 
-	virtual void setGpio15(bool v) override;
-	virtual bool getGpio15() override;
+	virtual void setGpio4(bool v) override;
+	virtual bool getGpio4() override;
 
 private:
 	// Defined message types from CPU to ESP

--- a/src/boards/rainbow_nrom.cpp
+++ b/src/boards/rainbow_nrom.cpp
@@ -125,7 +125,7 @@ static DECLFW(RAINBOW_NROMWriteFlags)
 
 static DECLFR(RAINBOW_NROMReadFlags)
 {
-	uint8 esp_rts_flag = esp->getGpio15() ? 0x80 : 0x00;
+	uint8 esp_rts_flag = esp->getGpio4() ? 0x80 : 0x00;
 	uint8 esp_enable_flag = esp_enable ? 0x01 : 0x00;
 	uint8 irq_enable_flag = irq_enable ? 0x40 : 0x00;
 	UDBG("RAINBOW read flags %04x => %02x\n", A, esp_rts_flag | esp_enable_flag | irq_enable_flag);
@@ -136,7 +136,7 @@ static void RAINBOW_NROMMapIrq(int32)
 {
 	if (irq_enable)
 	{
-		if (esp->getGpio15())
+		if (esp->getGpio4())
 		{
 			X6502_IRQBegin(FCEU_IQEXT);
 		}


### PR DESCRIPTION
New prototype now uses GPIO4 instead of GPIO15 to trigger IRQ because using GPIO15 could have caused some issue when flashing the ESP (never had any problem though, but just to be safe...)