### PR TITLE
rainbow: bugfix

### DIFF
--- a/src/boards/rainbow.cpp
+++ b/src/boards/rainbow.cpp
@@ -716,6 +716,7 @@ static void RainbowClose(void)
 	{
 		FCEU_gfree(DUMMY_CHRRAM);
 		DUMMY_CHRRAM = NULL;
+		ExtraNTARAM = NULL;
 	}
 
 	if (PRG_FLASHROM)


### PR DESCRIPTION
FCEUX was crashing when closing a CHR-ROM only Rainbow ROM.